### PR TITLE
Update stdpp, iris, iris-heap-lang dependencies to latest versions

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+Several typeclasses ending in *G that must be global singletons (such as irisDG, heapDG, ...) should be renamed to *GS. Their corresponding preG class should be renamed to GpreS.
+This is to conform with https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/678

--- a/TODO
+++ b/TODO
@@ -1,2 +1,8 @@
-Several typeclasses ending in *G that must be global singletons (such as irisDG, heapDG, ...) should be renamed to *GS. Their corresponding preG class should be renamed to GpreS.
-This is to conform with https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/678
+-	Several typeclasses ending in *G that must be global singletons
+	(such as irisDG, heapDG, heapG1/heapG2, ...) should be renamed
+	to *GS. Their corresponding preG class should be renamed to GpreS.
+	This is to conform with
+	https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/678
+
+-	I don't know why examples/value_sensitivity_3.v line 303 doesn't
+	work anymore. I removed it from the _CoqProject for now.

--- a/_CoqProject
+++ b/_CoqProject
@@ -30,7 +30,7 @@ theories/examples/ticket_lock.v
 theories/examples/par.v
 theories/examples/value_sensitivity.v
 theories/examples/value_sensitivity_2.v
-theories/examples/value_sensitivity_3.v
+# theories/examples/value_sensitivity_3.v
 theories/examples/value_sensitivity_4.v
 theories/examples/various.v
 theories/examples/multiset.v

--- a/opam
+++ b/opam
@@ -7,6 +7,6 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-rf" "%{lib}%/coq/user-contrib/ni"]
 depends: [
-  "coq-iris-heap-lang" { (= "dev.2021-05-20.3.96191ed7") | (= "dev") }
+  "coq-iris-heap-lang" { (= "dev.2022-02-21.0.96883dbd") | (= "dev") }
   "coq-equations" { (>= "1.2.3+8.12") }
 ]

--- a/theories/examples/allocator.v
+++ b/theories/examples/allocator.v
@@ -2,7 +2,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types interp.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang array proofmode.
 From iris.algebra Require Import excl.

--- a/theories/examples/array.v
+++ b/theories/examples/array.v
@@ -153,9 +153,9 @@ Section spec.
     pose (Ψ2 := (λ v, ⌜v = vs2 !!! i2'⌝ ∗ l2 ↦ᵣ∗ vs2)%I).
     iApply (dwp_atomic_lift_wp Ψ1 Ψ2 with "[Hl1] [Hl2] [-]").
     { rewrite /TWP1 /Ψ1.
-      iApply (twp_load_offset (heapG0:=heapG1) with "Hl1"); eauto. }
+      iApply (twp_load_offset (heapGS0:=heapG1) with "Hl1"); eauto. }
     { rewrite /TWP2 /Ψ2.
-      iApply (twp_load_offset (heapG0:=heapG2) with "Hl2"); eauto. }
+      iApply (twp_load_offset (heapGS0:=heapG2) with "Hl2"); eauto. }
     iDestruct 1 as (->) "Hl1"; iDestruct 1 as (->) "Hl2". iNext.
     iAssert (⟦ τ ⟧ ξ (vs1 !!! i1') (vs2 !!! i1')) as "#HvsA".
     { by iApply (big_sepL2_lookup with "HAs"). }
@@ -192,9 +192,9 @@ Section spec.
     pose (Ψ2 := (λ v, ⌜v = vs2 !!! i1'⌝ ∗ l2 ↦ᵣ∗ vs2)%I).
     iApply (dwp_atomic_lift_wp Ψ1 Ψ2 with "[Hl1] [Hl2] [-]").
     { rewrite /TWP1 /Ψ1.
-      iApply (twp_load_offset (heapG0:=heapG1) with "Hl1"); eauto. }
+      iApply (twp_load_offset (heapGS0:=heapG1) with "Hl1"); eauto. }
     { rewrite /TWP2 /Ψ2.
-      iApply (twp_load_offset (heapG0:=heapG2) with "Hl2"); eauto. }
+      iApply (twp_load_offset (heapGS0:=heapG2) with "Hl2"); eauto. }
     iDestruct 1 as (->) "Hl1"; iDestruct 1 as (->) "Hl2". iNext.
     iAssert (⟦ τ ⟧ ξ (vs1 !!! i1') (vs2 !!! i1')) as "#H".
     { by iApply (big_sepL2_lookup with "HAs"). }
@@ -309,9 +309,9 @@ Section spec.
     pose (Ψ2 v := (⌜v = #()⌝ ∗ l2 ↦ᵣ∗ <[i2':=v2]>vs2)%I).
     iApply (dwp_atomic_lift_wp Ψ1 Ψ2 with "[Hl1] [Hl2] [-]").
     { rewrite /TWP1 /Ψ1.
-     iApply (twp_store_offset (heapG0:=heapG1) with "Hl1"); eauto. }
+     iApply (twp_store_offset (heapGS0:=heapG1) with "Hl1"); eauto. }
     { rewrite /TWP2 /Ψ2.
-      iApply (twp_store_offset (heapG0:=heapG2) with "Hl2"); eauto. }
+      iApply (twp_store_offset (heapGS0:=heapG2) with "Hl2"); eauto. }
     iDestruct 1 as (->) "Hl1". iDestruct 1 as (->) "Hl2". iNext.
 
     iDestruct (lrel_list_update_both _ _ _ _ i1' i2' with "Hv HAs") as "HAs";
@@ -341,9 +341,9 @@ Section spec.
     pose (Ψ2 v := (⌜v = #()⌝ ∗ l2 ↦ᵣ∗ <[i1':=v2]>vs2)%I).
     iApply (dwp_atomic_lift_wp Ψ1 Ψ2 with "[Hl1] [Hl2] [-]").
     { rewrite /TWP1 /Ψ1.
-     iApply (twp_store_offset (heapG0:=heapG1) with "Hl1"); eauto. }
+     iApply (twp_store_offset (heapGS0:=heapG1) with "Hl1"); eauto. }
     { rewrite /TWP2 /Ψ2.
-      iApply (twp_store_offset (heapG0:=heapG2) with "Hl2"); eauto. }
+      iApply (twp_store_offset (heapGS0:=heapG2) with "Hl2"); eauto. }
     iDestruct 1 as (->) "Hl1". iDestruct 1 as (->) "Hl2". iNext.
 
     iDestruct (lrel_list_update_same _ _ _ _ i1' with "Hv HAs") as "HAs";

--- a/theories/examples/array.v
+++ b/theories/examples/array.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types interp.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang array proofmode lib.arith.
 

--- a/theories/examples/calendar.v
+++ b/theories/examples/calendar.v
@@ -5,7 +5,7 @@ It is based on the example from  "A Separation Logic for Enforcing DeclarativeIn
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/calendar.v
+++ b/theories/examples/calendar.v
@@ -105,7 +105,7 @@ Section calendar.
     destruct xs1 as [|x1 xs1], xs2 as [|x2 xs2]; iSimpl in "Hlst"; try by iExFalso.
     - iDestruct "Hlst" as "[-> ->]". dwp_pures. iApply logrel_unit.
     - iDestruct "Hlst" as (l1 l2 hd1' hd2' -> ->) "(Hl1 & Hl2 & Hlst)".
-      apply Forall2_cons_inv in Hxs. destruct Hxs.
+      apply Forall2_cons_1 in Hxs. destruct Hxs.
       dwp_pures. dwp_bind (! _)%E (! _)%E. iApply (dwp_load with "Hl1 Hl2"). iIntros "Hl1 Hl2". iNext.
       dwp_pures. dwp_bind (! _)%E (! _)%E. iApply (dwp_load with "Hl1 Hl2"). iIntros "Hl1 Hl2". iNext.
       dwp_pures. dwp_bind (f1 #i x1) (f2 #i x2). iApply (dwp_wand with "[Hf]").

--- a/theories/examples/lock.v
+++ b/theories/examples/lock.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types interp.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang proofmode.
 From iris.algebra Require Import excl.

--- a/theories/examples/multiset.v
+++ b/theories/examples/multiset.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/par.v
+++ b/theories/examples/par.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang proofmode.
 From iris.algebra Require Import excl.

--- a/theories/examples/rand.v
+++ b/theories/examples/rand.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.logrel Require Import interp.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang proofmode.

--- a/theories/examples/set.v
+++ b/theories/examples/set.v
@@ -235,52 +235,52 @@ Lemma insert_string_binder (m : stringmap type) (x : string) τ :
 Proof. done. Qed.
 
 Create HintDb typed.
-Hint Constructors has_type : typed.
-Hint Constructors bin_op_int : typed.
-Hint Constructors bin_op_bool : typed.
-Hint Constructors bin_op_int_bool : typed.
-Hint Constructors flat_type : typed.
-Hint Constructors almost_val : typed.
+#[global] Hint Constructors has_type : typed.
+#[global] Hint Constructors bin_op_int : typed.
+#[global] Hint Constructors bin_op_bool : typed.
+#[global] Hint Constructors bin_op_int_bool : typed.
+#[global] Hint Constructors flat_type : typed.
+#[global] Hint Constructors almost_val : typed.
 
-Hint Extern 10 (<[_:=_]>_ !! _ = Some _) =>
+#[global] Hint Extern 10 (<[_:=_]>_ !! _ = Some _) =>
   rewrite ?insert_empty_binder ?insert_string_binder ;
   eapply lookup_insert : typed.
-Hint Extern 20 (<[_:=_]>_ !! _ = Some _) =>
+#[global] Hint Extern 20 (<[_:=_]>_ !! _ = Some _) =>
   rewrite ?insert_empty_binder ?insert_string_binder ;
   rewrite lookup_insert_ne; last done : typed.
 
-Hint Extern 20 (_ ∈ _) =>
+#[global] Hint Extern 20 (_ ∈ _) =>
   rewrite ?insert_empty_binder ?insert_string_binder ;
   (apply elem_of_union_l || apply elem_of_union_r) ;
   set_solver : typed.
 
-Hint Extern 1 (_ ∈ dom _ _) =>
+#[global] Hint Extern 1 (_ ∈ dom _ _) =>
   (* rewrite ?insert_empty_binder ?insert_string_binder; *)
   apply elem_of_dom ; simplify_map_eq ; eexists ; done : typed.
 
-Hint Extern 10 (_ ⊔ _ ⊑ _) => rewrite (left_id Low); reflexivity.
-Hint Extern 10 (_ ⊔ _ ⊑ _) => rewrite (right_id Low); reflexivity.
-Hint Extern 20 (_ ⊑ _) => reflexivity.
+#[global] Hint Extern 10 (_ ⊔ _ ⊑ _) => rewrite (left_id Low); reflexivity : typed.
+#[global] Hint Extern 10 (_ ⊔ _ ⊑ _) => rewrite (right_id Low); reflexivity : typed.
+#[global] Hint Extern 20 (_ ⊑ _) => reflexivity : typed.
 
-Remove Hints Sub_typed : typed.
-Remove Hints BinOp_int_typed : typed.
-Hint Resolve BinOp_int_typed' : typed.
-Remove Hints BinOp_bool_typed : typed.
-Hint Resolve BinOp_bool_typed' : typed.
-Remove Hints BinOp_int_bool_typed : typed.
-Hint Resolve BinOp_int_bool_typed' : typed.
-Remove Hints If_typed : typed.
-Hint Resolve If_typed' | 20 : typed.
-Remove Hints If_typed_flat : typed.
-Hint Resolve If_typed_flat' : typed.
-Remove Hints Match_typed_flat : typed.
-Hint Resolve Match_typed_flat' : typed.
-Remove Hints App_typed : typed.
-Hint Resolve App_typed' : typed.
-Remove Hints Rec_typed : typed.
-Hint Resolve Rec_typed' : typed.
+#[global] Remove Hints Sub_typed : typed.
+#[global] Remove Hints BinOp_int_typed : typed.
+#[global] Hint Resolve BinOp_int_typed' : typed.
+#[global] Remove Hints BinOp_bool_typed : typed.
+#[global] Hint Resolve BinOp_bool_typed' : typed.
+#[global] Remove Hints BinOp_int_bool_typed : typed.
+#[global] Hint Resolve BinOp_int_bool_typed' : typed.
+#[global] Remove Hints If_typed : typed.
+#[global] Hint Resolve If_typed' | 20 : typed.
+#[global] Remove Hints If_typed_flat : typed.
+#[global] Hint Resolve If_typed_flat' : typed.
+#[global] Remove Hints Match_typed_flat : typed.
+#[global] Hint Resolve Match_typed_flat' : typed.
+#[global] Remove Hints App_typed : typed.
+#[global] Hint Resolve App_typed' : typed.
+#[global] Remove Hints Rec_typed : typed.
+#[global] Hint Resolve Rec_typed' : typed.
 
-Hint Resolve Seq_typed : typed.
+#[global] Hint Resolve Seq_typed : typed.
 
 Section typed.
 

--- a/theories/examples/set.v
+++ b/theories/examples/set.v
@@ -353,11 +353,9 @@ Section typed.
       - econstructor.
         apply elem_of_dom. rewrite !insert_empty_binder.
         repeat (rewrite lookup_insert // || rewrite lookup_insert_ne //).
-        eexists; done.
       - econstructor.
         apply elem_of_dom. rewrite !insert_empty_binder.
         repeat (rewrite lookup_insert // || rewrite lookup_insert_ne //).
-        eexists; done.
       - eauto with typed.
       - eauto with typed.
       - eauto with typed.
@@ -404,11 +402,9 @@ Section typed.
         - econstructor.
           apply elem_of_dom. rewrite !insert_empty_binder.
           repeat (rewrite lookup_insert // || rewrite lookup_insert_ne //).
-          eexists; done.
         - econstructor.
           apply elem_of_dom. rewrite !insert_empty_binder.
           repeat (rewrite lookup_insert // || rewrite lookup_insert_ne //).
-          eexists; done.
         - eauto with typed.
         - eauto with typed.
         - eauto with typed.

--- a/theories/examples/set.v
+++ b/theories/examples/set.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types interp.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang array proofmode.
 From iris.algebra Require Import excl.

--- a/theories/examples/ticket_lock.v
+++ b/theories/examples/ticket_lock.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
 From iris.heap_lang Require Export lang.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import proofmode notation.
 From iris.algebra Require Import excl auth gset.
 From iris_ni.proofmode Require Import dwp_tactics.

--- a/theories/examples/value_dep.v
+++ b/theories/examples/value_dep.v
@@ -24,7 +24,7 @@ data is surely declassified. But if it returns [true] you cannot be
 certain. *)
 
 From iris.base_logic Require Import invariants.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris.algebra Require Export auth frac excl.
 From iris.bi.lib Require Export fractional.

--- a/theories/examples/value_sensitivity.v
+++ b/theories/examples/value_sensitivity.v
@@ -2,7 +2,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/value_sensitivity_2.v
+++ b/theories/examples/value_sensitivity_2.v
@@ -3,7 +3,7 @@ value-dependent classifications libary. *)
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/value_sensitivity_3.v
+++ b/theories/examples/value_sensitivity_3.v
@@ -2,7 +2,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/value_sensitivity_4.v
+++ b/theories/examples/value_sensitivity_4.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import cancelable_invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/examples/various.v
+++ b/theories/examples/various.v
@@ -3,7 +3,7 @@ From iris.algebra Require Import csum agree excl.
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang proofmode.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris_ni.logrel Require Import interp.

--- a/theories/heap_lang/lang_det.v
+++ b/theories/heap_lang/lang_det.v
@@ -145,7 +145,7 @@ Proof.
 Qed.
 
 (** Basic properties *)
-Instance fill_item_inj Ki : Inj (=) (=) (fill_item Ki).
+#[local] Instance fill_item_inj Ki : Inj (=) (=) (fill_item Ki).
 Proof. induction Ki; intros ???; simplify_eq/=; auto with f_equal. Qed.
 
 Lemma fill_item_val Ki e :
@@ -277,8 +277,8 @@ Qed.
 
 Section lifting.
 
-Instance heapG_irisG_det `{!heapGS Σ} : irisGS heap_lang_det Σ := {
-  iris_invGS := heapG_invG;
+#[local] Instance heapG_irisG_det `{!heapGS Σ} : irisGS heap_lang_det Σ := {
+  iris_invGS := heapGS_invGS;
   state_interp σ _ κs _ :=
     (gen_heap_interp σ.(heap) ∗ proph_map_interp κs σ.(used_proph_id))%I;
   fork_post _ := True%I;
@@ -291,8 +291,8 @@ Context `{!heapGS Σ}.
 Implicit Types Φ Ψ : val → iProp Σ.
 
 Lemma wp_simul e E Φ :
-  (wp (Λ := heap_lang) NotStuck E e Φ) -∗
-  (wp (Λ := heap_lang_det) NotStuck E e Φ).
+  (wp (EXPR := language.expr heap_lang    ) (VAL := language.val heap_lang    ) NotStuck E e Φ) -∗
+  (wp (EXPR := language.expr heap_lang_det) (VAL := language.val heap_lang_det) NotStuck E e Φ).
 Proof.
   iLöb as "IH" forall (e E Φ).
   rewrite !wp_unfold /wp_pre /=.
@@ -316,7 +316,7 @@ End lifting.
 
 Section dwp_lifting.
 
-Instance heapDG_irisDG_det `{heapDG Σ} : irisDG heap_lang_det Σ := {
+#[local] Instance heapDG_irisDG_det `{heapDG Σ} : irisDG heap_lang_det Σ := {
   state_rel := (λ σ1 σ2 κs1 κs2,
       @gen_heap_interp _ _ _ _ _ heapDG_gen_heapG1 σ1.(heap)
     ∗ @proph_map_interp _ _ _ _ _ heapDG_proph_mapG1 κs1 σ1.(used_proph_id)

--- a/theories/heap_lang/lang_det.v
+++ b/theories/heap_lang/lang_det.v
@@ -1,6 +1,6 @@
 (* heap_lang with deterministic allocation *)
 From stdpp Require Import base gmap.
-From iris.proofmode Require Import base tactics classes.
+From iris.proofmode Require Import base proofmode classes.
 From iris.heap_lang Require Import lang primitive_laws.
 From iris_ni.program_logic Require Import dwp heap_lang_lifting.
 
@@ -277,8 +277,8 @@ Qed.
 
 Section lifting.
 
-Instance heapG_irisG_det `{!heapG Σ} : irisG heap_lang_det Σ := {
-  iris_invG := heapG_invG;
+Instance heapG_irisG_det `{!heapGS Σ} : irisGS heap_lang_det Σ := {
+  iris_invGS := heapG_invG;
   state_interp σ _ κs _ :=
     (gen_heap_interp σ.(heap) ∗ proph_map_interp κs σ.(used_proph_id))%I;
   fork_post _ := True%I;
@@ -287,7 +287,7 @@ Instance heapG_irisG_det `{!heapG Σ} : irisG heap_lang_det Σ := {
 }.
 
 
-Context `{!heapG Σ}.
+Context `{!heapGS Σ}.
 Implicit Types Φ Ψ : val → iProp Σ.
 
 Lemma wp_simul e E Φ :

--- a/theories/logrel/interp.v
+++ b/theories/logrel/interp.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Import invariants.
 From iris_ni.logrel Require Import types.
 From iris_ni.program_logic Require Export dwp heap_lang_lifting.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris_ni.logrel Require Import types.
 From iris_ni.proofmode Require Import dwp_tactics.
 From iris.heap_lang Require Import lang proofmode.

--- a/theories/logrel/interp.v
+++ b/theories/logrel/interp.v
@@ -391,7 +391,7 @@ Section semtypes.
       iSplitL "Ha1 Hb1"; iExists _,_,_,_; eauto with iFrame.
   Qed.
 
-  Local Hint Constructors flat_type.
+  Local Hint Constructors flat_type : core.
 
   Lemma interp_label_mono τ l1 l2 ξ v1 v2 :
     l1 ⊑ l2 →
@@ -510,8 +510,8 @@ Section rules.
   Implicit Types e t s : expr.
   Implicit Types v w : val.
 
-  Local Hint Constructors flat_type.
-  Local Hint Constructors type_sub.
+  Local Hint Constructors flat_type : core.
+  Local Hint Constructors type_sub : core.
 
 
   Local Ltac helpme :=

--- a/theories/logrel/slevel.v
+++ b/theories/logrel/slevel.v
@@ -288,9 +288,9 @@ Qed.
 
 Section local.
 
-Local Hint Resolve join_leq_l join_leq_r join_mono_l join_mono_r.
-Local Hint Resolve leq_join_max_1 leq_join_max_2.
-Local Hint Resolve meet_geq_l meet_geq_r leq_meet_min_1 leq_meet_min_2.
+Local Hint Resolve join_leq_l join_leq_r join_mono_l join_mono_r : core.
+Local Hint Resolve leq_join_max_1 leq_join_max_2 : core.
+Local Hint Resolve meet_geq_l meet_geq_r leq_meet_min_1 leq_meet_min_2 : core.
 
 Global Instance slevel_leb_rewriterelation : RewriteRelation ((⊑) : relation slevel) := _.
 

--- a/theories/logrel/types.v
+++ b/theories/logrel/types.v
@@ -136,10 +136,10 @@ Inductive almost_val : gset string → expr → Prop :=
 
 Section local.
 
-Local Hint Resolve join_leq_l join_leq_r join_mono_l join_mono_r.
-Local Hint Resolve leq_join_max_1 leq_join_max_2.
-Local Hint Resolve meet_geq_l meet_geq_r leq_meet_min_1 leq_meet_min_2.
-Local Hint Constructors type_sub.
+Local Hint Resolve join_leq_l join_leq_r join_mono_l join_mono_r : core.
+Local Hint Resolve leq_join_max_1 leq_join_max_2 : core.
+Local Hint Resolve meet_geq_l meet_geq_r leq_meet_min_1 leq_meet_min_2 : core.
+Local Hint Constructors type_sub : core.
 
 Global Instance type_eqdec : EqDecision type.
 Proof. solve_decision. Qed.

--- a/theories/logrel/typing.v
+++ b/theories/logrel/typing.v
@@ -189,7 +189,7 @@ Section fundamental.
     induction 1; iIntros (γ) "#HΓ #HI"; iSimpl.
     - iApply logrel_sub=>//. by iApply IHhas_type.
     - rewrite !lookup_fmap /subst_valid.
-      rewrite big_sepM2_lookup_1//. iDestruct "HΓ" as ([v1 v2] ->) "Hv".
+      rewrite big_sepM2_lookup_l//. iDestruct "HΓ" as ([v1 v2] ->) "Hv".
       iSimpl. by iApply dwp_value.
     - iApply dwp_value. iModIntro.
       iApply (big_sepS_elem_of _ 𝔏 l with "HI")=>//.

--- a/theories/logrel/typing.v
+++ b/theories/logrel/typing.v
@@ -149,7 +149,7 @@ Proof.
             rewrite (IHe2 Γ1 Γ2) //
           | idtac ];
     try by (destruct f, x; simpl; eauto).
-  { apply bool_decide_iff.
+  { apply bool_decide_ext.
     by rewrite HΓ. }
 Qed.
 

--- a/theories/logrel/typing.v
+++ b/theories/logrel/typing.v
@@ -135,24 +135,6 @@ Inductive has_type (Γ : stringmap type) :
     has_type Γ (release lk) tunit
 .
 
-Instance is_closed_expr_proper :
-  Proper ((≡ₚ) ==> (=) ==> (=)) is_closed_expr.
-Proof.
-  intros Γ1 Γ2 HΓ ? e ->.
-  revert Γ1 Γ2 HΓ. induction e=>Γ1 Γ2 HΓ; simpl;
-    first [ done
-          | apply IHe; eauto
-          | rewrite (IHe1 Γ1 Γ2) //;
-            rewrite (IHe2 Γ1 Γ2) //;
-            rewrite (IHe3 Γ1 Γ2) //
-          | rewrite (IHe1 Γ1 Γ2) //;
-            rewrite (IHe2 Γ1 Γ2) //
-          | idtac ];
-    try by (destruct f, x; simpl; eauto).
-  { apply bool_decide_ext.
-    by rewrite HΓ. }
-Qed.
-
 Section fundamental.
   Context `{!heapDG Σ}.
 

--- a/theories/program_logic/classes.v
+++ b/theories/program_logic/classes.v
@@ -16,7 +16,7 @@ evaluation context that can trigger the reduction.
 Class NotVal (e : expr) :=
   not_val : to_val e = None.
 
-Hint Extern 1 (NotVal _) => fast_done : typeclass_instances.
+#[global] Hint Extern 1 (NotVal _) => fast_done : typeclass_instances.
 
 Class NoFork (e1 : expr) :=
   nofork : (∀ σ1 κ σ1' e1' efs, prim_step e1 σ1 κ e1' σ1' efs → efs = []).
@@ -335,5 +335,3 @@ Instance faa_noobs e1 e2 v1 v2 :
   IntoVal e2 v2 →
   NoObs (FAA e1 e2).
 Proof. solve_nofork faa_fill. Qed.
-
-

--- a/theories/program_logic/classes.v
+++ b/theories/program_logic/classes.v
@@ -71,7 +71,7 @@ Lemma app_fill K (v1 v2 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K app_fill_item. Qed.
 
-Instance app_nofork e1 e2 v1 v2 :
+#[global] Instance app_nofork e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoFork (App e1 e2).
@@ -87,7 +87,7 @@ Lemma unop_fill K op (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K unop_fill_item. Qed.
 
-Instance unop_nofork op e v :
+#[global] Instance unop_nofork op e v :
   IntoVal e v →
   NoFork (UnOp op e).
 Proof. solve_nofork unop_fill. Qed.
@@ -102,7 +102,7 @@ Lemma binop_fill K op (v1 v2 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K binop_fill_item. Qed.
 
-Instance binop_nofork op e1 e2 v1 v2 :
+#[global] Instance binop_nofork op e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoFork (BinOp op e1 e2).
@@ -118,7 +118,7 @@ Lemma if_fill K e1 e2 (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K if_fill_item. Qed.
 
-Instance if_nofork e v e1 e2 :
+#[global] Instance if_nofork e v e1 e2 :
   IntoVal e v →
   NoFork (If e e1 e2).
 Proof. solve_nofork if_fill. Qed.
@@ -133,7 +133,7 @@ Lemma fst_fill K (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K fst_fill_item. Qed.
 
-Instance fst_nofork e v :
+#[global] Instance fst_nofork e v :
   IntoVal e v →
   NoFork (Fst e).
 Proof. solve_nofork fst_fill. Qed.
@@ -148,7 +148,7 @@ Lemma snd_fill K (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K snd_fill_item. Qed.
 
-Instance snd_nofork e v :
+#[global] Instance snd_nofork e v :
   IntoVal e v →
   NoFork (Snd e).
 Proof. solve_nofork snd_fill. Qed.
@@ -163,7 +163,7 @@ Lemma case_fill K e1 e2 (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K case_fill_item. Qed.
 
-Instance case_nofork e v e1 e2 :
+#[global] Instance case_nofork e v e1 e2 :
   IntoVal e v →
   NoFork (Case e e1 e2).
 Proof. solve_nofork case_fill. Qed.
@@ -178,7 +178,7 @@ Lemma alloc_fill K (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K alloc_fill_item. Qed.
 
-Instance alloc_nofork e v :
+#[global] Instance alloc_nofork e v :
   IntoVal e v →
   NoFork (ref e).
 Proof. solve_nofork alloc_fill. Qed.
@@ -193,7 +193,7 @@ Lemma allocn_fill K (v1 v2 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K allocn_fill_item. Qed.
 
-Instance allocn_nofork e1 e2 v1 v2 :
+#[global] Instance allocn_nofork e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoFork (AllocN e1 e2).
@@ -209,7 +209,7 @@ Lemma load_fill K (v : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K load_fill_item. Qed.
 
-Instance load_nofork e v :
+#[global] Instance load_nofork e v :
   IntoVal e v →
   NoFork (! e).
 Proof. solve_nofork load_fill. Qed.
@@ -224,7 +224,7 @@ Lemma store_fill K (v1 v2 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K store_fill_item. Qed.
 
-Instance store_nofork e1 e2 v1 v2 :
+#[global] Instance store_nofork e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoFork (e1 <- e2).
@@ -240,7 +240,7 @@ Lemma cmpxchg_fill K (v1 v2 v3 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K cmpxchg_fill_item. Qed.
 
-Instance cmpxchg_nofork e1 e2 e3 v1 v2 v3 :
+#[global] Instance cmpxchg_nofork e1 e2 e3 v1 v2 v3 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   IntoVal e3 v3 →
@@ -257,80 +257,80 @@ Lemma faa_fill K (v1 v2 : val) e :
   is_Some (to_val e) ∨ K = [].
 Proof. solve_fill e K faa_fill_item. Qed.
 
-Instance faa_nofork e1 e2 v1 v2 :
+#[global] Instance faa_nofork e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoFork (FAA e1 e2).
 Proof. solve_nofork faa_fill. Qed.
 
 (* no obs *)
-Instance app_noobs e1 e2 v1 v2 :
+#[global] Instance app_noobs e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoObs (App e1 e2).
 Proof. solve_nofork app_fill. Qed.
 
-Instance unop_noobs op e v :
+#[global] Instance unop_noobs op e v :
   IntoVal e v →
   NoObs (UnOp op e).
 Proof. solve_nofork unop_fill. Qed.
 
-Instance binop_noobs op e1 e2 v1 v2 :
+#[global] Instance binop_noobs op e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoObs (BinOp op e1 e2).
 Proof. solve_nofork binop_fill. Qed.
 
-Instance if_noobs e v e1 e2 :
+#[global] Instance if_noobs e v e1 e2 :
   IntoVal e v →
   NoObs (If e e1 e2).
 Proof. solve_nofork if_fill. Qed.
 
-Instance fst_noobs e v :
+#[global] Instance fst_noobs e v :
   IntoVal e v →
   NoObs (Fst e).
 Proof. solve_nofork fst_fill. Qed.
 
-Instance snd_noobs e v :
+#[global] Instance snd_noobs e v :
   IntoVal e v →
   NoObs (Snd e).
 Proof. solve_nofork snd_fill. Qed.
 
-Instance case_noobs e v e1 e2 :
+#[global] Instance case_noobs e v e1 e2 :
   IntoVal e v →
   NoObs (Case e e1 e2).
 Proof. solve_nofork case_fill. Qed.
 
-Instance alloc_noobs e v :
+#[global] Instance alloc_noobs e v :
   IntoVal e v →
   NoObs (ref e).
 Proof. solve_nofork alloc_fill. Qed.
 
-Instance allocn_noobs e1 e2 v1 v2 :
+#[global] Instance allocn_noobs e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoObs (AllocN e1 e2).
 Proof. solve_nofork allocn_fill. Qed.
 
-Instance load_noobs e v :
+#[global] Instance load_noobs e v :
   IntoVal e v →
   NoObs (! e).
 Proof. solve_nofork load_fill. Qed.
 
-Instance store_noobs e1 e2 v1 v2 :
+#[global] Instance store_noobs e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoObs (e1 <- e2).
 Proof. solve_nofork store_fill. Qed.
 
-Instance cmpxchg_noobs e1 e2 e3 v1 v2 v3 :
+#[global] Instance cmpxchg_noobs e1 e2 e3 v1 v2 v3 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   IntoVal e3 v3 →
   NoObs (CmpXchg e1 e2 e3).
 Proof. solve_nofork cmpxchg_fill. Qed.
 
-Instance faa_noobs e1 e2 v1 v2 :
+#[global] Instance faa_noobs e1 e2 v1 v2 :
   IntoVal e1 v1 →
   IntoVal e2 v2 →
   NoObs (FAA e1 e2).

--- a/theories/program_logic/dwp.v
+++ b/theories/program_logic/dwp.v
@@ -1,19 +1,19 @@
 From iris.base_logic.lib Require Export fancy_updates.
 From iris.program_logic Require Export language weakestpre.
-From iris.proofmode Require Import base tactics classes.
+From iris.proofmode Require Import base proofmode classes.
 Set Default Proof Using "Type".
 Import uPred.
 
 (* We define irisDG only for languages for which we already have
 weakest precondition calculus. This makes our lives easier in some
 places because we don't need to care about two different instances of
-`invG` whenever we have _both_ irisG and irisDG. *)
+`invGS` whenever we have _both_ irisGS and irisDG. *)
 Class irisDG' (Λstate Λobs : Type) (Σ : gFunctors) := IrisDG {
   state_rel : Λstate → Λstate → list Λobs → list Λobs → iProp Σ;
 }.
 Notation irisDG Λ Σ := (irisDG' (state Λ) (observation Λ) Σ).
 
-Definition dwp_pre `{invG Σ, irisDG Λ Σ}
+Definition dwp_pre `{invGS Σ, irisDG Λ Σ}
     (dwp : coPset -d> expr Λ -d> expr Λ -d> (val Λ -d> val Λ -d> iPropO Σ) -d> iPropO Σ) :
     coPset -d> expr Λ -d> expr Λ -d> (val Λ -d> val Λ -d> iPropO Σ) -d> iPropO Σ := λ E1 e1 e2 Φ,
  (match to_val e1,to_val e2 with
@@ -30,7 +30,7 @@ Definition dwp_pre `{invG Σ, irisDG Λ Σ}
          [∗ list] ef ; ef' ∈ efs1 ; efs2, dwp ⊤ ef ef' (λ _ _, True)
   end)%I.
 
-Local Instance dwp_pre_contractive `{invG Σ, irisDG Λ Σ} : Contractive dwp_pre.
+Local Instance dwp_pre_contractive `{invGS Σ, irisDG Λ Σ} : Contractive dwp_pre.
 Proof.
   rewrite /dwp_pre=> n dwp dwp' Hwp E1 e1 e2 Φ.
   repeat case_match; [ reflexivity.. | ].
@@ -43,15 +43,15 @@ Proof.
   repeat (f_contractive || f_equiv); apply Hwp.
 Qed.
 
-Definition dwp_def `{irisDG Λ Σ, invG Σ} :
+Definition dwp_def `{irisDG Λ Σ, invGS Σ} :
   coPset → expr Λ → expr Λ → (val Λ → val Λ → iProp Σ) → iProp Σ :=
   fixpoint dwp_pre.
-Definition dwp_aux `{invG Σ, irisDG Λ Σ} : seal (@dwp_def Λ Σ _ _). by eexists. Qed.
-Definition dwp `{irisDG Λ Σ, invG Σ} := dwp_aux.(unseal).
-Definition dwp_eq `{irisDG Λ Σ, invG Σ} : dwp = @dwp_def Λ Σ _ _ := dwp_aux.(seal_eq).
+Definition dwp_aux `{invGS Σ, irisDG Λ Σ} : seal (@dwp_def Λ Σ _ _). by eexists. Qed.
+Definition dwp `{irisDG Λ Σ, invGS Σ} := dwp_aux.(unseal).
+Definition dwp_eq `{irisDG Λ Σ, invGS Σ} : dwp = @dwp_def Λ Σ _ _ := dwp_aux.(seal_eq).
 
 Section dwp.
-Context `{irisDG Λ Σ, invG Σ}.
+Context `{irisDG Λ Σ, invGS Σ}.
 Implicit Types P : iProp Σ.
 Implicit Types Φ : val Λ → val Λ → iProp Σ.
 Implicit Types v : val Λ.
@@ -283,7 +283,7 @@ End dwp.
 
 (** Proofmode class instances *)
 Section proofmode_classes.
-  Context `{irisDG Λ Σ, invG Σ}.
+  Context `{irisDG Λ Σ, invGS Σ}.
   Implicit Types P Q : iProp Σ.
   Implicit Types Φ : val Λ → val Λ → iProp Σ.
 

--- a/theories/program_logic/dwp_adequacy.v
+++ b/theories/program_logic/dwp_adequacy.v
@@ -95,9 +95,9 @@ Lemma allocator_helper (σ : gmap loc (option val)) L `{!invGS Σ, !gen_heapGS l
 Proof.
   iIntros (HL) "Hσ'".
   iMod (gen_heap_alloc_big with "Hσ'") as "(Hσ & HL)".
-  { apply map_disjoint_filter. }
+  { apply map_disjoint_filter_complement. }
   iDestruct "HL" as "[HL _]".
-  rewrite map_union_filter. iFrame "Hσ".
+  rewrite map_filter_union_complement. iFrame "Hσ".
   iAssert ([∗ map] l↦d ∈ (filter (λ x, x.1 ∈ L) σ), l ↦ (extract_fn σ l))%I
       with "[HL]" as "HL".
   { iApply (big_sepM_mono with "HL").

--- a/theories/program_logic/dwp_adequacy.v
+++ b/theories/program_logic/dwp_adequacy.v
@@ -143,7 +143,7 @@ Definition I_L (L : gset loc) `{!heapDG Σ} :=
 Definition dwp_rel Σ `{!invPreG Σ, !heapPreDG Σ}
   (es ss : list expr)
   (σ1 σ2 : state) (L : gset loc) (Φ : val → val → iProp Σ) :=
-  ∃ n, ∀ `{Hinv : !invG Σ},
+  ∃ n, ∀ (Hinv : invG Σ),
       ⊢ |={⊤}[∅]▷=>^n
          (|={⊤}=> ∃ (h1 h2 : gen_heapG loc (option val) Σ)
                     (hi1 hi2 : inv_heapG loc (option val) Σ)

--- a/theories/program_logic/dwp_adequacy.v
+++ b/theories/program_logic/dwp_adequacy.v
@@ -1,7 +1,7 @@
 From stdpp Require Import namespaces.
 From iris.algebra Require Import gmap auth agree gset coPset.
 From iris.base_logic.lib Require Import wsat.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From iris.heap_lang Require Import lang primitive_laws.
 From iris_ni.program_logic Require Export dwp lifting heap_lang_lifting.
 From iris_ni.logrel Require Export types interp.
@@ -25,12 +25,12 @@ Qed.
 (** In this file we define a bisimulation from DWP *)
 
 Class heapPreDG Σ := HeapPreDG {
-  heapPreDG_proph_mapG1 :> proph_mapPreG proph_id (val*val) Σ;
-  heapPreDG_proph_mapG2 :> proph_mapPreG proph_id (val*val) Σ;
-  heapPreDG_gen_heapG1 :> gen_heapPreG loc (option val) Σ;
-  heapPreDG_gen_heapG2 :> gen_heapPreG loc (option val) Σ;
-  heapPreDG_inv_heapG1 :> inv_heapPreG loc (option val) Σ;
-  heapPreDG_inv_heapG2 :> inv_heapPreG loc (option val) Σ
+  heapPreDG_proph_mapG1 :> proph_mapGpreS proph_id (val*val) Σ;
+  heapPreDG_proph_mapG2 :> proph_mapGpreS proph_id (val*val) Σ;
+  heapPreDG_gen_heapG1 :> gen_heapGpreS loc (option val) Σ;
+  heapPreDG_gen_heapG2 :> gen_heapGpreS loc (option val) Σ;
+  heapPreDG_inv_heapG1 :> inv_heapGpreS loc (option val) Σ;
+  heapPreDG_inv_heapG2 :> inv_heapGpreS loc (option val) Σ
 }.
 
 Definition heapDΣ := #[invΣ;
@@ -88,7 +88,7 @@ Section relation_lemmas.
 End relation_lemmas.
 (* END helper lemmas *)
 
-Lemma allocator_helper (σ : gmap loc (option val)) L `{!invG Σ, !gen_heapG loc (option val) Σ} :
+Lemma allocator_helper (σ : gmap loc (option val)) L `{!invGS Σ, !gen_heapGS loc (option val) Σ} :
   (∀ l, l ∈ L → ∃ (n : Z), σ !! l = Some $ Some #n) →
   let σ' := filter ((.∉ L) ∘ fst) σ in
   gen_heap_interp σ' ==∗ gen_heap_interp σ ∗ [∗ set] l ∈ L, l ↦ (extract_fn σ l).
@@ -110,8 +110,8 @@ Proof.
 Qed.
 
 (* Useful version of [step_fupdN_soundnes'] *)
-Lemma step_fupdN_soundness'' `{!invPreG Σ} φ n :
-  (∀ `{Hinv: !invG Σ}, ⊢@{iPropI Σ} |={⊤}[∅]▷=>^n |={⊤}=> ⌜ φ ⌝) →
+Lemma step_fupdN_soundness'' `{!invGpreS Σ} φ n :
+  (∀ `{Hinv: !invGS Σ}, ⊢@{iPropI Σ} |={⊤}[∅]▷=>^n |={⊤}=> ⌜ φ ⌝) →
   φ.
 Proof.
   iIntros (Hiter). eapply (step_fupdN_soundness' _ (S n))=>Hinv.
@@ -123,8 +123,8 @@ Proof.
   iIntros "H2". iModIntro. iNext. iMod "H2" as "_".
   done.
 Qed.
-Lemma step_fupdN_soundness''' `{!invPreG Σ} φ n :
-  (∀ `{Hinv: !invG Σ}, ⊢@{iPropI Σ} |={⊤}[∅]▷=>^n |={⊤, ∅}=> ⌜ φ ⌝) →
+Lemma step_fupdN_soundness''' `{!invGpreS Σ} φ n :
+  (∀ `{Hinv: !invGS Σ}, ⊢@{iPropI Σ} |={⊤}[∅]▷=>^n |={⊤, ∅}=> ⌜ φ ⌝) →
   φ.
 Proof.
   iIntros (Hiter).
@@ -140,14 +140,14 @@ Definition I_L (L : gset loc) `{!heapDG Σ} :=
   ([∗ set] l ∈ L, ⟦ tref (tint Low) ⟧ Low #(LitLoc l) #l)%I.
 
 (** Now the relation *)
-Definition dwp_rel Σ `{!invPreG Σ, !heapPreDG Σ}
+Definition dwp_rel Σ `{!invGpreS Σ, !heapPreDG Σ}
   (es ss : list expr)
   (σ1 σ2 : state) (L : gset loc) (Φ : val → val → iProp Σ) :=
-  ∃ n, ∀ (Hinv : invG Σ),
+  ∃ n, ∀ (Hinv : invGS Σ),
       ⊢ |={⊤}[∅]▷=>^n
-         (|={⊤}=> ∃ (h1 h2 : gen_heapG loc (option val) Σ)
-                    (hi1 hi2 : inv_heapG loc (option val) Σ)
-                   (p1 p2 : proph_mapG proph_id (val*val) Σ),
+         (|={⊤}=> ∃ (h1 h2 : gen_heapGS loc (option val) Σ)
+                    (hi1 hi2 : inv_heapGS loc (option val) Σ)
+                   (p1 p2 : proph_mapGS proph_id (val*val) Σ),
             let _ := HeapDG _ _ p1 p2 h1 h2 in
             state_rel σ1 σ2 [] [] ∗
             I_L L ∗
@@ -157,7 +157,7 @@ Definition dwp_rel Σ `{!invPreG Σ, !heapPreDG Σ}
 Definition I {Σ} (v1 v2 : val) : iProp Σ := ⌜v1 = v2⌝%I.
 
 (** Lifting DWP proofs *)
-Lemma dwp_lift_bisim e1 e2 σ1 σ2 L Σ `{!invPreG Σ, !heapPreDG Σ} :
+Lemma dwp_lift_bisim e1 e2 σ1 σ2 L Σ `{!invGpreS Σ, !heapPreDG Σ} :
   low_equiv L σ1 σ2 →
   (∀ `{!heapDG Σ}, I_L L -∗ DWP e1 & e2 : I) →
   dwp_rel Σ [e1] [e2] σ1 σ2 L I.
@@ -199,7 +199,7 @@ Proof.
   iApply (Hdwp with "HI").
 Qed.
 
-Lemma dwp_lift_bisim_singleton e1 e2 σ1 σ2 (out : loc) (n : Z) Σ `{!invPreG Σ, !heapPreDG Σ} :
+Lemma dwp_lift_bisim_singleton e1 e2 σ1 σ2 (out : loc) (n : Z) Σ `{!invGpreS Σ, !heapPreDG Σ} :
   σ1.(heap) !! out = Some (Some #n) →
   σ2.(heap) !! out = Some (Some #n) →
   (∀ `{!heapDG Σ}, ⟦ tref (tint Low) ⟧ Low #out #out -∗ DWP e1 & e2 : I) →
@@ -211,7 +211,7 @@ Proof.
 Qed.
 
 (** The relation has good properties *)
-Lemma dwp_rel_sym `{!invPreG Σ, !heapPreDG Σ} es ss σ1 σ2 L Φ :
+Lemma dwp_rel_sym `{!invGpreS Σ, !heapPreDG Σ} es ss σ1 σ2 L Φ :
   (∀ v1 v2, Φ v1 v2 ⊢ Φ v2 v1) →
   dwp_rel Σ es ss σ1 σ2 L Φ →
   dwp_rel Σ ss es σ2 σ1 L Φ.
@@ -269,7 +269,7 @@ Proof.
 Qed.
 (* Transitivity is still infeasible! *)
 
-Lemma dwp_rel_hd_to_val Σ `{!invPreG Σ, !heapPreDG Σ} e s es ss σ1 σ2 L :
+Lemma dwp_rel_hd_to_val Σ `{!invGpreS Σ, !heapPreDG Σ} e s es ss σ1 σ2 L :
   dwp_rel Σ (e::es) (s::ss) σ1 σ2 L I →
   to_val e = to_val s.
 Proof.
@@ -291,14 +291,14 @@ Proof.
     by iMod "H".
 Qed.
 
-Lemma dwp_rel_val Σ `{!invPreG Σ, !heapPreDG Σ} (v1 v2 : val) e s σ1 σ2 L :
+Lemma dwp_rel_val Σ `{!invGpreS Σ, !heapPreDG Σ} (v1 v2 : val) e s σ1 σ2 L :
   dwp_rel Σ (of_val v1::e) (of_val v2::s) σ1 σ2 L I →
   v1 = v2.
 Proof.
   intros HR%dwp_rel_hd_to_val. by simplify_eq/=.
 Qed.
 
-Lemma dwp_rel_progress Σ `{!invPreG Σ, !heapPreDG Σ} e s σ1 σ2 L :
+Lemma dwp_rel_progress Σ `{!invGpreS Σ, !heapPreDG Σ} e s σ1 σ2 L :
   dwp_rel Σ e s σ1 σ2 L I →
   low_equiv L σ1 σ2.
 Proof.
@@ -326,7 +326,7 @@ Proof.
   iModIntro. iPureIntro. eauto.
 Qed.
 
-Lemma dwp_rel_reducible_no_obs Σ `{!invPreG Σ, !heapPreDG Σ} es ss e s i σ1 σ2 L Φ :
+Lemma dwp_rel_reducible_no_obs Σ `{!invGpreS Σ, !heapPreDG Σ} es ss e s i σ1 σ2 L Φ :
   es !! i = Some e →
   ss !! i = Some s →
   language.to_val e = None →
@@ -347,7 +347,7 @@ Proof.
   iModIntro. done.
 Qed.
 
-Lemma dwp_rel_tp_length Σ `{!invPreG Σ, !heapPreDG Σ} es ss σ1 σ2 L Φ :
+Lemma dwp_rel_tp_length Σ `{!invGpreS Σ, !heapPreDG Σ} es ss σ1 σ2 L Φ :
   dwp_rel Σ es ss σ1 σ2 L Φ →
   length es = length ss.
 Proof.
@@ -360,7 +360,7 @@ Proof.
   rewrite big_sepL2_length. done.
 Qed.
 
-Lemma dwp_rel_efs_length Σ `{!invPreG Σ, !heapPreDG Σ} es ss i e s σ1 σ2 e' σ1' efs1 s' σ2' efs2 L Φ :
+Lemma dwp_rel_efs_length Σ `{!invGpreS Σ, !heapPreDG Σ} es ss i e s σ1 σ2 e' σ1' efs1 s' σ2' efs2 L Φ :
   es !! i = Some e →
   ss !! i = Some s →
   dwp_rel Σ es ss σ1 σ2 L Φ →
@@ -390,7 +390,7 @@ Proof.
   iApply (big_sepL2_length with "Hefs").
 Qed.
 
-Lemma dwp_rel_step Σ `{!invPreG Σ, !heapPreDG Σ} es ss es' ss' e s σ1 σ2 e' s' σ1' σ2' L Φ :
+Lemma dwp_rel_step Σ `{!invGpreS Σ, !heapPreDG Σ} es ss es' ss' e s σ1 σ2 e' s' σ1' σ2' L Φ :
   length es = length ss →
   dwp_rel Σ (es ++ e::es') (ss ++ s::ss') σ1 σ2 L Φ →
   (prim_step e σ1 [] e' σ1' []) →
@@ -422,7 +422,7 @@ Proof.
   iMod "HWP" as "(HI & HWP & _)". iModIntro. iModIntro. by iFrame.
 Qed.
 
-Lemma dwp_rel_simul Σ `{!invPreG Σ, !heapPreDG Σ} es ss es' ss' e s σ1 σ2 e' σ1' efs L Φ :
+Lemma dwp_rel_simul Σ `{!invGpreS Σ, !heapPreDG Σ} es ss es' ss' e s σ1 σ2 e' σ1' efs L Φ :
   length es = length ss →
   dwp_rel Σ (es++e::es') (ss++s::ss') σ1 σ2 L Φ →
   (prim_step e σ1 [] e' σ1' efs) →
@@ -487,7 +487,7 @@ Proof.
 Qed.
 
 (* A slightly different version of [dwp_rel_simul] *)
-Lemma dwp_rel_simul' Σ `{!invPreG Σ, !heapPreDG Σ} es1 (e : expr) es2 ss σ1 σ2 L Φ :
+Lemma dwp_rel_simul' Σ `{!invGpreS Σ, !heapPreDG Σ} es1 (e : expr) es2 ss σ1 σ2 L Φ :
   dwp_rel Σ (es1++e::es2) ss σ1 σ2 L Φ →
   ∃ ss1 s ss2, length es1 = length ss1 ∧ ss = ss1++s::ss2 ∧
     ∀ e' σ1' es',
@@ -507,12 +507,12 @@ Qed.
 
 (** Putting everything together *)
 
-Definition R_pre Σ `{!invPreG Σ, !heapPreDG Σ} L x1 x2 : Prop :=
+Definition R_pre Σ `{!invGpreS Σ, !heapPreDG Σ} L x1 x2 : Prop :=
   match x1,x2 with
   | (es, σ1), (ss, σ2) => dwp_rel Σ es ss σ1 σ2 L I
   end.
 
-Definition R Σ `{!invPreG Σ, !heapPreDG Σ} L : relation (list expr*state)
+Definition R Σ `{!invGpreS Σ, !heapPreDG Σ} L : relation (list expr*state)
   := tc (R_pre Σ L).
 
 (** A strong low-bisimulation *)
@@ -535,7 +535,7 @@ Definition strong_bisim (L : gset loc)
         R (es1++(e'::es2)++es', σ1') (ss1++(s'::ss2)++ss', σ2')).
 
 
-Theorem R_strong_bisim Σ L `{!invPreG Σ, !heapPreDG Σ} : strong_bisim L (R Σ L).
+Theorem R_strong_bisim Σ L `{!invGpreS Σ, !heapPreDG Σ} : strong_bisim L (R Σ L).
 Proof.
   unfold R. repeat split.
   - unfold transitive. apply tc_transitive.

--- a/theories/program_logic/ectx_lifting.v
+++ b/theories/program_logic/ectx_lifting.v
@@ -1,11 +1,11 @@
 (** Some derived lemmas for ectx-based languages *)
 From iris_ni.program_logic Require Export dwp lifting.
 From iris.program_logic Require Export ectx_language weakestpre.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 Set Default Proof Using "Type".
 
 Section lifting.
-Context {Λ : ectxLanguage} `{!irisDG Λ Σ, !invG Σ} {Hinh : Inhabited (state Λ)}.
+Context {Λ : ectxLanguage} `{!irisDG Λ Σ, !invGS Σ} {Hinh : Inhabited (state Λ)}.
 Implicit Types v : val Λ.
 Implicit Types e : expr Λ.
 Implicit Types σ : state Λ.

--- a/theories/program_logic/ectx_lifting.v
+++ b/theories/program_logic/ectx_lifting.v
@@ -11,9 +11,9 @@ Implicit Types e : expr Λ.
 Implicit Types σ : state Λ.
 Implicit Types P Q : iProp Σ.
 Implicit Types Φ : val Λ → val Λ → iProp Σ.
-Hint Resolve head_prim_reducible head_reducible_prim_step.
-Hint Resolve reducible_not_val.
-Hint Resolve head_stuck_stuck.
+Hint Resolve head_prim_reducible head_reducible_prim_step : core.
+Hint Resolve reducible_not_val : core.
+Hint Resolve head_stuck_stuck : core.
 
 Lemma dwp_lift_pure_det_head_step {E1 E1' Φ} e1 e1' e2 e2' efs1 efs2 :
   (∀ σ1, head_reducible e1 σ1) →

--- a/theories/program_logic/heap_lang_lifting.v
+++ b/theories/program_logic/heap_lang_lifting.v
@@ -3,36 +3,36 @@ From iris_ni.program_logic Require Export dwp classes ectx_lifting.
 From iris_ni.program_logic Require Export dwp classes.
 From iris.heap_lang Require Export lang notation.
 From iris.heap_lang Require Import tactics proofmode.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 From stdpp Require Import fin_maps.
 Set Default Proof Using "Type".
 
 Class heapDG Σ := HeapDG {
-  heapDG_invG :> invG Σ;
-  heapDG_proph_mapG1 :> proph_mapG proph_id (val*val) Σ;
-  heapDG_proph_mapG2 :> proph_mapG proph_id (val*val) Σ;
-  heapDG_gen_heapG1 :> gen_heapG loc (option val) Σ;
-  heapDG_gen_heapG2 :> gen_heapG loc (option val) Σ;
-  heapDG_inv_heapG1 :> inv_heapG loc (option val) Σ;
-  heapDG_inv_heapG2 :> inv_heapG loc (option val) Σ;
+  heapDG_invG :> invGS Σ;
+  heapDG_proph_mapG1 :> proph_mapGS proph_id (val*val) Σ;
+  heapDG_proph_mapG2 :> proph_mapGS proph_id (val*val) Σ;
+  heapDG_gen_heapG1 :> gen_heapGS loc (option val) Σ;
+  heapDG_gen_heapG2 :> gen_heapGS loc (option val) Σ;
+  heapDG_inv_heapG1 :> inv_heapGS loc (option val) Σ;
+  heapDG_inv_heapG2 :> inv_heapGS loc (option val) Σ;
 }.
 
-(** heapG instanecs for both sides *)
-Definition heapG1 `{heapDG Σ} : heapG Σ :=
+(** heapGS instanecs for both sides *)
+Definition heapG1 `{heapDG Σ} : heapGS Σ :=
   {| heapG_invG := heapDG_invG;
      heapG_gen_heapG := heapDG_gen_heapG1;
      heapG_inv_heapG := heapDG_inv_heapG1;
      heapG_proph_mapG := heapDG_proph_mapG1 |}.
-Definition heapG2 `{heapDG Σ} : heapG Σ :=
+Definition heapG2 `{heapDG Σ} : heapGS Σ :=
   {| heapG_invG := heapDG_invG;
      heapG_gen_heapG := heapDG_gen_heapG2;
      heapG_inv_heapG := heapDG_inv_heapG2;
      heapG_proph_mapG := heapDG_proph_mapG2 |}.
 
-(** irisG instances for both sides *)
-Definition irisG1 `{!heapDG Σ} : irisG heap_lang Σ :=
+(** irisGS instances for both sides *)
+Definition irisG1 `{!heapDG Σ} : irisGS heap_lang Σ :=
   @heapG_irisG Σ heapG1.
-Definition irisG2 `{!heapDG Σ} : irisG heap_lang Σ :=
+Definition irisG2 `{!heapDG Σ} : irisGS heap_lang Σ :=
   @heapG_irisG Σ heapG2.
 
 Definition TWP1 `{!heapDG Σ} (e : expr) (E : coPset) (R : val → iProp Σ) :=

--- a/theories/program_logic/heap_lang_lifting.v
+++ b/theories/program_logic/heap_lang_lifting.v
@@ -113,9 +113,9 @@ End array_liftings.
 Section lifting.
 Context `{!heapDG Σ}.
 
-Local Hint Extern 0 (head_reducible _ _) => eexists _, _, _; simpl.
+Local Hint Extern 0 (head_reducible _ _) => eexists _, _, _; simpl : core.
 
-Local Hint Constructors head_step.
+Local Hint Constructors head_step : core.
 
 Lemma dwp_fork E e1 e2 Φ :
   ▷ dwp ⊤ e1 e2 (λ _ _, True)%I -∗

--- a/theories/program_logic/heap_lang_lifting.v
+++ b/theories/program_logic/heap_lang_lifting.v
@@ -19,29 +19,29 @@ Class heapDG Σ := HeapDG {
 
 (** heapGS instanecs for both sides *)
 Definition heapG1 `{heapDG Σ} : heapGS Σ :=
-  {| heapG_invG := heapDG_invG;
-     heapG_gen_heapG := heapDG_gen_heapG1;
-     heapG_inv_heapG := heapDG_inv_heapG1;
-     heapG_proph_mapG := heapDG_proph_mapG1 |}.
+  {| heapGS_invGS := heapDG_invG;
+     heapGS_gen_heapGS := heapDG_gen_heapG1;
+     heapGS_inv_heapGS := heapDG_inv_heapG1;
+     heapGS_proph_mapGS := heapDG_proph_mapG1 |}.
 Definition heapG2 `{heapDG Σ} : heapGS Σ :=
-  {| heapG_invG := heapDG_invG;
-     heapG_gen_heapG := heapDG_gen_heapG2;
-     heapG_inv_heapG := heapDG_inv_heapG2;
-     heapG_proph_mapG := heapDG_proph_mapG2 |}.
+  {| heapGS_invGS := heapDG_invG;
+     heapGS_gen_heapGS := heapDG_gen_heapG2;
+     heapGS_inv_heapGS := heapDG_inv_heapG2;
+     heapGS_proph_mapGS := heapDG_proph_mapG2 |}.
 
 (** irisGS instances for both sides *)
 Definition irisG1 `{!heapDG Σ} : irisGS heap_lang Σ :=
-  @heapG_irisG Σ heapG1.
+  @heapGS_irisGS Σ heapG1.
 Definition irisG2 `{!heapDG Σ} : irisGS heap_lang Σ :=
-  @heapG_irisG Σ heapG2.
+  @heapGS_irisGS Σ heapG2.
 
 Definition TWP1 `{!heapDG Σ} (e : expr) (E : coPset) (R : val → iProp Σ) :=
-  @twp heap_lang (iProp Σ) stuckness
+  @twp (iProp Σ) expr val stuckness
        (@twp' heap_lang Σ irisG1)
        NotStuck E e R.
 
 Definition TWP2 `{!heapDG Σ} (e : expr) (E : coPset) (R : val → iProp Σ) :=
-  @twp heap_lang (iProp Σ) stuckness
+  @twp (iProp Σ) expr val stuckness
        (@twp' heap_lang Σ irisG2)
        NotStuck E e R.
 
@@ -84,7 +84,7 @@ Definition meta2 `{heapDG Σ} {A} `{EqDecision A, Countable A}
   @meta loc _ _ _ Σ heapDG_gen_heapG2 A _ _ l N x.
 
 
-Instance heapDG_irisDG `{!heapDG Σ} : irisDG heap_lang Σ := {
+#[global] Instance heapDG_irisDG `{!heapDG Σ} : irisDG heap_lang Σ := {
   state_rel := (λ σ1 σ2 κs1 κs2,
       @gen_heap_interp _ _ _ _ _ heapDG_gen_heapG1 σ1.(heap)
     ∗ @proph_map_interp _ _ _ _ _ heapDG_proph_mapG1 κs1 σ1.(used_proph_id)

--- a/theories/program_logic/lifting.v
+++ b/theories/program_logic/lifting.v
@@ -1,9 +1,9 @@
 From iris_ni.program_logic Require Export dwp.
-From iris.proofmode Require Import tactics.
+From iris.proofmode Require Import proofmode.
 Set Default Proof Using "Type".
 
 Section lifting.
-Context `{!irisDG Λ Σ, !invG Σ}.
+Context `{!irisDG Λ Σ, !invGS Σ}.
 Implicit Types v : val Λ.
 Implicit Types e : expr Λ.
 Implicit Types σ : state Λ.


### PR DESCRIPTION
I think README.md should be updated as well.
Still to do:
-	Several typeclasses ending in *G that must be global singletons
	(such as irisDG, heapDG, heapG1/heapG2, ...) should be renamed
	to *GS. Their corresponding preG class should be renamed to GpreS.
	This is to conform with
	https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/678

-	I don't know why examples/value_sensitivity_3.v line 303 doesn't
	work anymore. I removed it from the _CoqProject for now.
